### PR TITLE
Fix libpcre2-dev install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
       - image: ponylang/ponyc:release
     steps:
+      - run: apt-get update
       - run: apt-get install -y libpcre2-dev
       - checkout
       - run: make test config=release
@@ -12,6 +13,7 @@ jobs:
     docker:
       - image: ponylang/ponyc:release
     steps:
+      - run: apt-get update
       - run: apt-get install -y libpcre2-dev
       - checkout
       - run: make test config=debug
@@ -20,6 +22,7 @@ jobs:
     docker:
       - image: ponylang/ponyc:latest
     steps:
+      - run: apt-get update
       - run: apt-get install -y libpcre2-dev
       - checkout
       - run: make test config=release
@@ -28,6 +31,7 @@ jobs:
     docker:
       - image: ponylang/ponyc:latest
     steps:
+      - run: apt-get update
       - run: apt-get install -y libpcre2-dev
       - checkout
       - run: make test config=debug


### PR DESCRIPTION
It's not working. Even though that is the same command we issued
previously in the container this uses. Why? No idea. Let's try
doing an update first to find it.

Very odd.