### PR TITLE
Remove unneeded curl installation during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - image: ponylang/ponyc:release
     steps:
       - run: apt-get update
-      - run: apt-get install -y libpcre2-dev curl
+      - run: apt-get install -y libpcre2-dev
       - checkout
       - run: make test config=release
       - zulip/status:
@@ -20,7 +20,7 @@ jobs:
       - image: ponylang/ponyc:release
     steps:
       - run: apt-get update
-      - run: apt-get install -y libpcre2-dev curl
+      - run: apt-get install -y libpcre2-dev 
       - checkout
       - run: make test config=debug
       - zulip/status: 


### PR DESCRIPTION
curl is now provided in the release image. We don't need to install
it.

Closes #8