### PR TITLE
Update prce2 download location

### DIFF
--- a/.release-notes/37.md
+++ b/.release-notes/37.md
@@ -1,0 +1,3 @@
+## Update pcre2 download location
+
+The pcre2 download location used to automatically install the native library on Windows has been updated after the old FTP site was shut down.

--- a/make.ps1
+++ b/make.ps1
@@ -156,7 +156,7 @@ function BuildLibs
     {
       $pcre2Zip = "$pcre2.zip"
       $pcre2ZipTgt = Join-Path -Path $libsDir -ChildPath $pcre2Zip
-      if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://ftp.pcre.org/pub/pcre/$pcre2Zip" -OutFile $pcre2ZipTgt }
+      if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PhilipHazel/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
       7z.exe x -y $pcre2ZipTgt "-o$libsDir"
       if ($LastExitCode -ne 0) { throw "Error downloading and unzipping $pcre2Zip" }
     }


### PR DESCRIPTION
It's moved. The old ftp is no longer active.