### PR TITLE
Use the native `Expand-Archive` command on Windows instead of 7-Zip

### DIFF
--- a/.release-notes/60.md
+++ b/.release-notes/60.md
@@ -1,0 +1,3 @@
+## Use the native `Expand-Archive` command on Windows to extract PCRE source
+
+Prior to this we were using 7Zip, which is installed on our CI environments but not by default on Windows, to extract the PCRE source zip file; we now use the native Windows PowerShell command.

--- a/make.ps1
+++ b/make.ps1
@@ -157,8 +157,9 @@ function BuildLibs
       $pcre2Zip = "$pcre2.zip"
       $pcre2ZipTgt = Join-Path -Path $libsDir -ChildPath $pcre2Zip
       if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PhilipHazel/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
+      Write-Output "Expand-Archive -Force -LiteralPath `"$pcre2ZipTgt`" -DestinationPath `"$libsDir`""
       $output = Expand-Archive -Force -LiteralPath "$pcre2ZipTgt" -DestinationPath "$libsDir"
-      Write-Host $output
+      Write-Output $output
       if ($LastExitCode -ne 0) { throw "Error downloading and unzipping $pcre2Zip" }
     }
 

--- a/make.ps1
+++ b/make.ps1
@@ -157,7 +157,7 @@ function BuildLibs
       $pcre2Zip = "$pcre2.zip"
       $pcre2ZipTgt = Join-Path -Path $libsDir -ChildPath $pcre2Zip
       if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PhilipHazel/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
-      Expand-Archive -Path $pcre2ZipTgt -DestinationPath "$libsDir"
+      Expand-Archive -Force -Path $pcre2ZipTgt -DestinationPath "$libsDir"
       if ($LastExitCode -ne 0) { throw "Error downloading and unzipping $pcre2Zip" }
     }
 

--- a/make.ps1
+++ b/make.ps1
@@ -158,9 +158,7 @@ function BuildLibs
       $pcre2ZipTgt = Join-Path -Path $libsDir -ChildPath $pcre2Zip
       if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PhilipHazel/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
       Write-Output "Expand-Archive -Force -LiteralPath `"$pcre2ZipTgt`" -DestinationPath `"$libsDir`""
-      $output = Expand-Archive -Force -LiteralPath "$pcre2ZipTgt" -DestinationPath "$libsDir"
-      Write-Output $output
-      if ($LastExitCode -ne 0) { throw "Error downloading and unzipping $pcre2Zip" }
+      Expand-Archive -Force -LiteralPath "$pcre2ZipTgt" -DestinationPath "$libsDir"
     }
 
     # Write-Output "Building $pcre2"

--- a/make.ps1
+++ b/make.ps1
@@ -157,7 +157,8 @@ function BuildLibs
       $pcre2Zip = "$pcre2.zip"
       $pcre2ZipTgt = Join-Path -Path $libsDir -ChildPath $pcre2Zip
       if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PhilipHazel/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
-      Expand-Archive -Force -LiteralPath $pcre2ZipTgt -DestinationPath "$libsDir"
+      $output = Expand-Archive -Force -LiteralPath "$pcre2ZipTgt" -DestinationPath "$libsDir"
+      Write-Host $output
       if ($LastExitCode -ne 0) { throw "Error downloading and unzipping $pcre2Zip" }
     }
 

--- a/make.ps1
+++ b/make.ps1
@@ -157,7 +157,7 @@ function BuildLibs
       $pcre2Zip = "$pcre2.zip"
       $pcre2ZipTgt = Join-Path -Path $libsDir -ChildPath $pcre2Zip
       if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PhilipHazel/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
-      7z.exe x -y $pcre2ZipTgt "-o$libsDir"
+      Expand-Archive -Path $pcre2ZipTgt -DestinationPath "$libsDir"
       if ($LastExitCode -ne 0) { throw "Error downloading and unzipping $pcre2Zip" }
     }
 

--- a/make.ps1
+++ b/make.ps1
@@ -157,7 +157,7 @@ function BuildLibs
       $pcre2Zip = "$pcre2.zip"
       $pcre2ZipTgt = Join-Path -Path $libsDir -ChildPath $pcre2Zip
       if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PhilipHazel/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
-      Expand-Archive -Force -Path $pcre2ZipTgt -DestinationPath "$libsDir"
+      Expand-Archive -Force -LiteralPath $pcre2ZipTgt -DestinationPath "$libsDir"
       if ($LastExitCode -ne 0) { throw "Error downloading and unzipping $pcre2Zip" }
     }
 


### PR DESCRIPTION
7-Zip is installed on our CI environments, but is not installed by default on Windows.