### PR TITLE
Fix find recursion in examples discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
 endif
 
 SOURCE_FILES := $(shell find $(SRC_DIR) -name *.pony)
-EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -type d))
+EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -maxdepth 0 -type d))
 EXAMPLES_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name *.pony)
 EXAMPLES_BINARIES := $(addprefix $(BUILD_DIR)/,$(EXAMPLES))
 


### PR DESCRIPTION
The find command that discovers example directories recurses into subdirectories. Adding \`-maxdepth 0\` prevents this. Without the fix, any example with a subdirectory would be treated as a separate example, breaking the build. Discovered in ponylang/hobby.