### PR TITLE
Update PCRE2 to 10.47 on Windows

### DIFF
--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   windows:
     name: Verify main against the latest ponyc on Windows
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Disable Windows Defender
         run: Set-MpPreference -DisableRealtimeMonitoring $true

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Check workflow files
-        uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
+        uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260529
         with:
           args: -color

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
 
   vs-ponyc-release-windows:
     name: Test against recent ponyc release on Windows
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Disable Windows Defender
         run: Set-MpPreference -DisableRealtimeMonitoring $true

--- a/.release-notes/update-pcre2.md
+++ b/.release-notes/update-pcre2.md
@@ -1,0 +1,3 @@
+## Update PCRE2 to 10.47 on Windows
+
+The PCRE2 library that this package builds and links on Windows has been updated to version 10.47. Linux and macOS builds link the system-provided PCRE2 and are unaffected.

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ If you use [Corral](https://github.com/ponylang/corral) to include this package 
 ### Building PCRE2 from source
 
 ```bash
-wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
-tar xvf pcre2-10.21.tar.bz2
-cd pcre2-10.21
+wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.bz2
+tar xvf pcre2-10.47.tar.bz2
+cd pcre2-10.47
 ./configure --prefix=/usr
 make
 sudo make install

--- a/make.ps1
+++ b/make.ps1
@@ -145,7 +145,7 @@ function BuildTest
 
 function BuildLibs
 {
-  $pcre2 = "pcre2-10.35"
+  $pcre2 = "pcre2-10.47"
   $pcre2LibTgt = Join-Path -Path $rootDir -ChildPath "pcre2-8.lib"
 
   if (-not (Test-Path $pcre2LibTgt))
@@ -156,13 +156,15 @@ function BuildLibs
     {
       $pcre2Zip = "$pcre2.zip"
       $pcre2ZipTgt = Join-Path -Path $libsDir -ChildPath $pcre2Zip
-      if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PhilipHazel/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
+      if (-not (Test-Path $pcre2ZipTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://github.com/PCRE2Project/pcre2/releases/download/$pcre2/$pcre2Zip" -OutFile $pcre2ZipTgt }
       Write-Output "Expand-Archive -Force -LiteralPath `"$pcre2ZipTgt`" -DestinationPath `"$libsDir`""
       Expand-Archive -Force -LiteralPath "$pcre2ZipTgt" -DestinationPath "$libsDir"
     }
 
     # Write-Output "Building $pcre2"
-    $pcre2Lib = Join-Path -Path $libsDir -ChildPath "lib/pcre2-8.lib"
+    # PCRE2's CMake build names the static library `pcre2-8-static.lib`; we
+    # copy it to `pcre2-8.lib` below so Pony's `use "lib:pcre2-8"` finds it.
+    $pcre2Lib = Join-Path -Path $libsDir -ChildPath "lib/pcre2-8-static.lib"
 
     if (-not (Test-Path $pcre2Lib))
     {


### PR DESCRIPTION
Updates the PCRE2 that this package builds and links **on Windows** from 10.35 to 10.47. Linux and macOS builds link the system-provided PCRE2 and are unaffected by this change.

This was prompted by moving Windows CI to the `windows-2025-vs2026` runner (ahead of GitHub's redirect of `windows-2025` on 2026-06-15): that image's CMake removed compatibility with `cmake_minimum_required < 3.5`, which the old vendored pcre2-10.35 declares, so it no longer configures. PCRE2 10.47 targets a modern CMake minimum. The download URL is also moved to the canonical `PCRE2Project/pcre2` releases, the built static library is now picked up under its current name (`pcre2-8-static.lib`), and the stale from-source instructions in the README are refreshed.

Also bumps the actionlint CI image to `20260529` so the new runner label passes workflow linting.